### PR TITLE
#13 resolveCall enhancements

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,2 +1,2 @@
 todo:
-  keyword: [ "todo", "fixme" ]
+  keyword: [ "todo", "fixme", "techdebt", "tbd" ]

--- a/annotations/source/glued/annotations/common_annotations.d
+++ b/annotations/source/glued/annotations/common_annotations.d
@@ -56,8 +56,6 @@ struct RepetitionBoundaries {
         assert(lowerInc < upperExc);
     }
     
-    //this() assert both are positive
-    
     bool check(int occurences){
         return occurences >= lowerInc && occurences < upperExc;
     }
@@ -91,5 +89,5 @@ enum anyNumber = RepetitionBoundaries(0, size_t.max);
 @Metaannotation
 @CheckedBy!(RepeatableChecker)
 struct Repeatable {
-    RepetitionBoundaries boundaries;
+    RepetitionBoundaries boundaries = anyNumber;
 }

--- a/annotations/source/glued/annotations/core_annotations.d
+++ b/annotations/source/glued/annotations/core_annotations.d
@@ -53,3 +53,19 @@ struct Implies(alias S) if (is(typeof(S) == struct)) { //todo ditto
         alias getImplicated = Alias!(S); 
     } 
 }
+
+//todo sanitize these; maybe some documentational UDA?
+
+///UDA for "magic annotations" like OnParameter, that should be filtered out
+/// when retrieving target annotations
+//todo Implies is magic, checkedby and nonimplicable as well
+enum GluedMagic;
+
+//@Repeatable
+//@Target(TargetType.FUNCTION)
+@GluedMagic
+struct OnParameter(size_t _paramIdx, alias _annotation)
+{
+    enum paramIdx = _paramIdx;
+    alias annotation = _annotation;
+}

--- a/annotations/source/glued/annotations/core_annotations.d
+++ b/annotations/source/glued/annotations/core_annotations.d
@@ -68,4 +68,17 @@ struct OnParameter(size_t _paramIdx, alias _annotation)
 {
     enum paramIdx = _paramIdx;
     alias annotation = _annotation;
+    
+    enum describesParam(string name, size_t idx) = (idx == paramIdx);
+}
+
+//@Repeatable
+//@Target(TargetType.FUNCTION)
+@GluedMagic
+struct OnParameter(string _paramName, alias _annotation)
+{
+    enum paramName = _paramName;
+    alias annotation = _annotation;
+    
+    enum describesParam(string name, size_t idx) = (name == paramName);
 }

--- a/annotations/source/glued/annotations/core_impl.d
+++ b/annotations/source/glued/annotations/core_impl.d
@@ -109,19 +109,14 @@ template getExplicitAnnotations(alias M)
                                     __traits(hasMember, X, "paramIdx"); //todo check types of these fields
     static if (isParamPointer!M)
     {
-        //todo clean up these debug "logs" (check "functions" testsuite too)
-//        pragma(msg, __FILE__, ":", __LINE__);
         
         alias OnParameterUDAs = staticMap!(expandToData, getUDAs!(M.Target, OnParameter));
-//        pragma(msg, "PARAM UDA ", M.stringof, " -> ", OnParameterUDAs);
         
         enum pred(alias U) = U.describesParam!(M.paramName, M.paramIdx);
         alias relevant = Filter!(pred, OnParameterUDAs);
-//        pragma(msg, "PARAM RELEVANT ", M.stringof, " -> ", relevant);
         
         enum unpack(alias X) = expandToData!(X.annotation);
         alias getExplicitAnnotations = staticMap!(unpack, relevant);
-//        pragma(msg, "PARAM RESULT ", M.stringof, " -> ", getExplicitAnnotations);
     }
     else
     {

--- a/annotations/source/glued/annotations/core_impl.d
+++ b/annotations/source/glued/annotations/core_impl.d
@@ -8,7 +8,8 @@ import glued.annotations.core_annotations;
 import glued.annotations.validation_impl;
 import glued.utils: ofType, toType, toAnnotableType;
 
-private struct ParameterPointer(alias Foo){
+private struct ParameterPointer(alias Foo)
+{
     alias Target = Foo;
     string paramName;
     size_t paramIdx;
@@ -106,7 +107,9 @@ template getExplicitAnnotations(alias M)
 {
     enum isParamPointer(alias X) = __traits(hasMember, X, "Target") &&
                                     __traits(hasMember, X, "paramName") &&
-                                    __traits(hasMember, X, "paramIdx"); //todo check types of these fields
+                                    is(typeof(X.paramName) == string) &&
+                                    __traits(hasMember, X, "paramIdx") &&
+                                    is(typeof(X.paramIdx) == size_t);
     static if (isParamPointer!M)
     {
         

--- a/annotations/source/glued/annotations/package.d
+++ b/annotations/source/glued/annotations/package.d
@@ -1,3 +1,0 @@
-module glued.annotations;
-
-public import glued.annotations.api;

--- a/annotations/source/glued/annotations/package.d
+++ b/annotations/source/glued/annotations/package.d
@@ -1,4 +1,4 @@
-module glued.annotations.api;
+module glued.annotations;
 
 public import glued.annotations.core_annotations;
 public import glued.annotations.common_annotations;

--- a/annotations/source/glued/annotations/package.d
+++ b/annotations/source/glued/annotations/package.d
@@ -3,4 +3,4 @@ module glued.annotations;
 public import glued.annotations.core_annotations;
 public import glued.annotations.common_annotations;
 public import glued.annotations.common_impl: TargetTypeOf, TargetType;
-public import glued.annotations.core_impl: getAnnotation, getAnnotations, hasOneAnnotation, hasAnnotation;
+public import glued.annotations.core_impl: getAnnotation, getAnnotations, hasOneAnnotation, hasAnnotation, parameter;

--- a/annotations/source/glued/annotations/package.d
+++ b/annotations/source/glued/annotations/package.d
@@ -1,3 +1,6 @@
+//fixme reorganize this mess of modules, their names and tests
+//body tests are badly organized (should be module-per-feature), main code as 
+//well (rest of glue-d doesn't use underscores, amongst other issues)
 module glued.annotations;
 
 public import glued.annotations.core_annotations;

--- a/annotations/test/glued/testsuites/functions.d
+++ b/annotations/test/glued/testsuites/functions.d
@@ -1,0 +1,24 @@
+module glued.testsuites.functions;
+
+import std.meta;
+
+import glued.annotations;
+
+struct S1 { int x; }
+struct S2 { int x; }
+struct S3 { int x; }
+struct S4 { int x; }
+
+@OnParameter!(0, S1)
+@OnParameter!(0, S2(3))
+@OnParameter!(1, S3())
+//@OnParameter!("s", S4)
+//@OnParameter!("x", S2())
+void foo(int x, string s, bool b){}
+
+unittest
+{
+//    pragma(msg, getAnnotations!(parameter!(foo, 0)));
+    static assert(getAnnotations!(parameter!(foo, 0)) == AliasSeq!(S1(), S2(3)));
+//    static assert(getAnnotations!(parameter!(foo, 0)) == AliasSeq!(S1(), S2(3), S2()));
+}

--- a/annotations/test/glued/testsuites/functions.d
+++ b/annotations/test/glued/testsuites/functions.d
@@ -42,3 +42,44 @@ unittest
     
     static assert(getAnnotations!(foo) == AliasSeq!(S1()));
 }
+
+class C {
+    @OnParameter!(0, S1)
+    @OnParameter!(0, S2(3))
+    @OnParameter!(1, S3())
+    @OnParameter!("s", S4)
+    @OnParameter!("x", S2())
+    @S1
+    void baz(int x, string s, bool b){}
+}
+
+unittest
+{
+    alias bar = __traits(getOverloads, C, "baz")[0];
+    static assert(getAnnotations!(parameter!(bar, 0)) == AliasSeq!(S1(), S2(3), S2()));
+    static assert(getAnnotations!(parameter!(bar, "x")) == AliasSeq!(S1(), S2(3), S2()));
+    
+    static assert(getAnnotations!(parameter!(bar, 1)) == AliasSeq!(S3(), S4(), S1(7), S3(5)));
+    static assert(getAnnotations!(parameter!(bar, "s")) == AliasSeq!(S3(), S4(), S1(7), S3(5)));
+    
+    static assert(getAnnotations!(parameter!(bar, 2)).length == 0);
+    static assert(getAnnotations!(parameter!(bar, "b")).length == 0);
+    
+    static assert(getAnnotations!(bar) == AliasSeq!(S1()));
+}
+
+unittest
+{
+    C c = new C;
+    auto bar = typeof(&(__traits(getOverloads, c, "baz")[0]));
+    static assert(getAnnotations!(parameter!(bar, 0)) == AliasSeq!(S1(), S2(3), S2()));
+    static assert(getAnnotations!(parameter!(bar, "x")) == AliasSeq!(S1(), S2(3), S2()));
+    
+    static assert(getAnnotations!(parameter!(bar, 1)) == AliasSeq!(S3(), S4(), S1(7), S3(5)));
+    static assert(getAnnotations!(parameter!(bar, "s")) == AliasSeq!(S3(), S4(), S1(7), S3(5)));
+    
+    static assert(getAnnotations!(parameter!(bar, 2)).length == 0);
+    static assert(getAnnotations!(parameter!(bar, "b")).length == 0);
+    
+    static assert(getAnnotations!(bar) == AliasSeq!(S1()));
+}

--- a/annotations/test/glued/testsuites/functions.d
+++ b/annotations/test/glued/testsuites/functions.d
@@ -67,19 +67,3 @@ unittest
     
     static assert(getAnnotations!(bar) == AliasSeq!(S1()));
 }
-
-unittest
-{
-    C c = new C;
-    auto bar = typeof(&(__traits(getOverloads, c, "baz")[0]));
-    static assert(getAnnotations!(parameter!(bar, 0)) == AliasSeq!(S1(), S2(3), S2()));
-    static assert(getAnnotations!(parameter!(bar, "x")) == AliasSeq!(S1(), S2(3), S2()));
-    
-    static assert(getAnnotations!(parameter!(bar, 1)) == AliasSeq!(S3(), S4(), S1(7), S3(5)));
-    static assert(getAnnotations!(parameter!(bar, "s")) == AliasSeq!(S3(), S4(), S1(7), S3(5)));
-    
-    static assert(getAnnotations!(parameter!(bar, 2)).length == 0);
-    static assert(getAnnotations!(parameter!(bar, "b")).length == 0);
-    
-    static assert(getAnnotations!(bar) == AliasSeq!(S1()));
-}

--- a/annotations/test/glued/testsuites/functions.d
+++ b/annotations/test/glued/testsuites/functions.d
@@ -20,6 +20,7 @@ struct S4 { int x; }
 @OnParameter!(1, S3())
 @OnParameter!("s", S4)
 @OnParameter!("x", S2())
+@S1
 void foo(int x, string s, bool b){}
 
 
@@ -38,4 +39,6 @@ unittest
     
     static assert(getAnnotations!(parameter!(foo, 2)).length == 0);
     static assert(getAnnotations!(parameter!(foo, "b")).length == 0);
+    
+    static assert(getAnnotations!(foo) == AliasSeq!(S1()));
 }

--- a/annotations/test/glued/testsuites/functions.d
+++ b/annotations/test/glued/testsuites/functions.d
@@ -1,24 +1,41 @@
 module glued.testsuites.functions;
 
 import std.meta;
+import std.traits;
+import std.algorithm;
 
 import glued.annotations;
 
 struct S1 { int x; }
 struct S2 { int x; }
+
+@Implies!(S1(7))
 struct S3 { int x; }
+
+@Implies!(S3(5))
 struct S4 { int x; }
 
 @OnParameter!(0, S1)
 @OnParameter!(0, S2(3))
 @OnParameter!(1, S3())
-//@OnParameter!("s", S4)
-//@OnParameter!("x", S2())
+@OnParameter!("s", S4)
+@OnParameter!("x", S2())
 void foo(int x, string s, bool b){}
 
+
+//todo annotation unittests assume ordering in asserts
+//body contract doesn't specify the order, so this may lead to env-dependent tests
+// and give an impression that tests fully define the contract
+
+//todo test checkers(validation) on parameter annotations
 unittest
 {
-//    pragma(msg, getAnnotations!(parameter!(foo, 0)));
-    static assert(getAnnotations!(parameter!(foo, 0)) == AliasSeq!(S1(), S2(3)));
-//    static assert(getAnnotations!(parameter!(foo, 0)) == AliasSeq!(S1(), S2(3), S2()));
+    static assert(getAnnotations!(parameter!(foo, 0)) == AliasSeq!(S1(), S2(3), S2()));
+    static assert(getAnnotations!(parameter!(foo, "x")) == AliasSeq!(S1(), S2(3), S2()));
+    
+    static assert(getAnnotations!(parameter!(foo, 1)) == AliasSeq!(S3(), S4(), S1(7), S3(5)));
+    static assert(getAnnotations!(parameter!(foo, "s")) == AliasSeq!(S3(), S4(), S1(7), S3(5)));
+    
+    static assert(getAnnotations!(parameter!(foo, 2)).length == 0);
+    static assert(getAnnotations!(parameter!(foo, "b")).length == 0);
 }

--- a/source/glued/application/di/annotations.d
+++ b/source/glued/application/di/annotations.d
@@ -45,4 +45,6 @@ struct Autowire(T=DefaultQuery) {
  * Used to indicate that annotated target should not be injected, e.g. when
  * injecting sole constructor.
  */
+ //todo DontInject should clash with Autowire, Constructor (and PostConstruct in the future)
+ //body mentioned annotations require checkers; we should also add constraints on repeatability and targets
 struct DontInject {}

--- a/source/glued/application/di/initializers.d
+++ b/source/glued/application/di/initializers.d
@@ -197,7 +197,7 @@ class ComponentSeedInitializer(T): InstanceInitializer!(T, false)
                     {
                         assert(!ctorCalled);
                         log.debug_.emit("Calling constructor for seed ", &t, " of type ", fullyQualifiedName!T);
-                        resolveCall(this.injector, &__traits(getOverloads, t, "__ctor")[i]);
+                        resolveCall!(__traits(getOverloads, T, "__ctor")[i])(this.injector, &__traits(getOverloads, t, "__ctor")[i]);
                         log.debug_.emit("Called constructor for instance", &t);
                         ctorCalled = true;
                     }

--- a/source/glued/application/di/providers.d
+++ b/source/glued/application/di/providers.d
@@ -45,7 +45,7 @@ class ConfigurationMethodProvider(C, string name, size_t i): Provider {
         C config = injector.get!C;
         log.debug_.emit("Resolved configuration class ", fullyQualifiedName!C, " instance ", &config);
         log.debug_.emit("Building configuration method ", fullyQualifiedName!C, ".", name);
-        auto instance = resolveCall(injector, &__traits(getOverloads, config, name)[i]);
+        auto instance = resolveCall!(__traits(getOverloads, C, name)[i])(injector, &__traits(getOverloads, config, name)[i]);
         enum isSeed = hasOneAnnotation!(__traits(getOverloads, C, name)[i], Seed); //todo assert not has many
         log.debug_.emit("Built initialized instance ", &instance, " method ", fullyQualifiedName!C, ".", name);
         auto initializer = isSeed ? new InstanceInitializer!(C, true)(injector) : new NullInitializer;

--- a/source/glued/application/di/resolveCall.d
+++ b/source/glued/application/di/resolveCall.d
@@ -29,7 +29,7 @@ auto resolveCall(alias Def, F...)(Dejector injector, F foo)
 
 
     static string generateResolvedExpression(){
-        //todo extension point when we introduce environment (key/val config)
+        //extension point when we introduce environment (key/val config)
         string result = "toCall(";
         string[] params;
         static foreach (i, p; P){

--- a/source/glued/application/di/resolveCall.d
+++ b/source/glued/application/di/resolveCall.d
@@ -1,21 +1,25 @@
 module glued.application.di.resolveCall;
 
+import std.meta;
 import std.traits: moduleName, fullyQualifiedName, isCallable, Parameters, ReturnType;
 import std.array: join;
 import std.functional;
 
 import glued.logging;
+import glued.annotations;
+
+import glued.application.di.annotations;
 
 import dejector;
 
-auto resolveCall(F...)(Dejector injector, F foo)
+auto resolveCall(alias Def, F...)(Dejector injector, F foo)
     if (isCallable!(F))
 {
     alias R = ReturnType!F;
     alias P = Parameters!F;
     auto toCall = cast(R delegate(P)) toDelegate(foo);
     
-    string generateImports(){
+    static string generateImports(){
         string result;
         static foreach (p; P){
             result ~= "import "~moduleName!p~";\n";
@@ -24,12 +28,19 @@ auto resolveCall(F...)(Dejector injector, F foo)
     }
 
 
-    string generateResolvedExpression(){
+    static string generateResolvedExpression(){
         //todo extension point when we introduce environment (key/val config)
         string result = "toCall(";
         string[] params;
-        static foreach (p; P){
-            params ~= "injector.get!("~fullyQualifiedName!p~")";
+        static foreach (i, p; P){
+            static if (hasOneAnnotation!(parameter!(Def, i), Autowire))
+            {
+                params ~= "injector.get!("~fullyQualifiedName!(getAnnotation!(parameter!(Def, i), Autowire).Query)~")";
+            }
+            else
+            {
+                params ~= "injector.get!("~fullyQualifiedName!p~")";
+            }
         }
         result ~= params.join(", ");
         result ~= ")";

--- a/source/glued/application/di/resolveCall.d
+++ b/source/glued/application/di/resolveCall.d
@@ -2,47 +2,44 @@ module glued.application.di.resolveCall;
 
 import std.traits: moduleName, fullyQualifiedName, isCallable, Parameters, ReturnType;
 import std.array: join;
+import std.functional;
 
 import glued.logging;
 
 import dejector;
 
-string generateImports(P...)(){
-    string result;
-    static foreach (p; P){
-        result ~= "import "~moduleName!p~";\n";
-    }
-    return result;
-}
-
-
-string generateResolvedExpression(P...)(){
-    //todo extension point when we introduce environment (key/val config)
-    string result = "toCall(";
-    string[] params;
-    static foreach (p; P){
-        params ~= "injector.get!("~fullyQualifiedName!p~")";
-    }
-    result ~= params.join(", ");
-    result ~= ")";
-    return result;
-}
-
-auto resolveCall(F...)(Dejector injector, F toCall)
+auto resolveCall(F...)(Dejector injector, F foo)
     if (isCallable!(F))
 {
     alias R = ReturnType!F;
     alias P = Parameters!F;
-    return resolveCall!(R, P)(cast(R delegate(P)) toDelegate(toCall));
-}
+    auto toCall = cast(R delegate(P)) toDelegate(foo);
+    
+    string generateImports(){
+        string result;
+        static foreach (p; P){
+            result ~= "import "~moduleName!p~";\n";
+        }
+        return result;
+    }
 
-//todo add @Param(int idx/string name, alias annotations)
-auto resolveCall(R, P...)(Dejector injector, R delegate(P) toCall)
-{
+
+    string generateResolvedExpression(){
+        //todo extension point when we introduce environment (key/val config)
+        string result = "toCall(";
+        string[] params;
+        static foreach (p; P){
+            params ~= "injector.get!("~fullyQualifiedName!p~")";
+        }
+        result ~= params.join(", ");
+        result ~= ")";
+        return result;
+    }
+    
     mixin CreateLogger;
     static if (is(R == void)){
-        mixin(Logger.logged!(generateImports!(P)()~generateResolvedExpression!(P)()~";"));
+        mixin(Logger.logged!(generateImports()~generateResolvedExpression()~";"));
     } else {
-        mixin(Logger.logged.value!(generateImports!(P)()~"return "~generateResolvedExpression!(P)()~";"));
+        mixin(Logger.logged.value!(generateImports()~"return "~generateResolvedExpression()~";"));
     }
 }

--- a/source/glued/application/package.d
+++ b/source/glued/application/package.d
@@ -8,3 +8,4 @@ public import glued.application.stereotypes;
 public import glued.application.di.annotations;
 public import glued.codescan.scannable;
 
+public import glued.application.di.resolveCall;

--- a/test/foo/api.d
+++ b/test/foo/api.d
@@ -4,10 +4,7 @@ import glued.application; //ditto from operators
 
 import foo.operators;
 
-interface FooWithExpected {
-    int foo(int x);
-    int expected(int x);
-}
+import glued.testutils: FooWithExpected;
 
 @Component
 class FooByField: FooWithExpected

--- a/test/foo/config.d
+++ b/test/foo/config.d
@@ -22,10 +22,6 @@ class Config {
 // it wires types in different way, so tests for api should fail if this gets
 // registered
 class IgnoredConfig {
-//    public override void registerDependencies(shared(DependencyContainer) container) {
-//        container.register!(Operator, Power);
-//    }
-    
     @Component
     Multiply multiply(){
         return new Multiply();

--- a/test/glued/testsuites/application/di/resolveCall.d
+++ b/test/glued/testsuites/application/di/resolveCall.d
@@ -41,7 +41,7 @@ class FooForFunction: FooWithExpected
 }
 
 @OnParameter!(0, Autowire!Power)
-auto freeFunctionByIdx(Operator power, Operator multiply, Add add)
+auto freeFunctionByFirstIdx(Operator power, Operator multiply, Add add)
 {
     return new FooForFunction(power, multiply, add);
 }
@@ -52,10 +52,334 @@ unittest {
     auto r = new GluedRuntime!(at("foo"))();
     r.start();
     
-    import foo.api;
-    auto impl = resolveCall!(freeFunctionByIdx)(r.injector, &freeFunctionByIdx);
-    assert(impl !is null);
+    auto impl = resolveCall!(freeFunctionByFirstIdx)(r.injector, &freeFunctionByFirstIdx);
 
     compareResults(impl, [0, 1, 2, 5], 5);
-    log.info.emit("resolveCall with free function and params by idx passed");
+    log.info.emit("resolveCall with free function and params by first idx passed");
+}
+
+@OnParameter!(1, Autowire!Power)
+auto freeFunctionByMiddleIdx(Operator multiply, Operator power, Add add)
+{
+    return new FooForFunction(power, multiply, add);
+}
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    auto impl = resolveCall!(freeFunctionByMiddleIdx)(r.injector, &freeFunctionByMiddleIdx);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with free function and params by middle idx passed");
+}
+
+@OnParameter!(2, Autowire!Power)
+auto freeFunctionByLastIdx(Operator multiply, Add add, Operator power)
+{
+    return new FooForFunction(power, multiply, add);
+}
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+
+    auto impl = resolveCall!(freeFunctionByLastIdx)(r.injector, &freeFunctionByLastIdx);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with free function and params by last idx passed");
+}
+
+
+@OnParameter!("power", Autowire!Power)
+auto freeFunctionByFirstName(Operator power, Operator multiply, Add add)
+{
+    return new FooForFunction(power, multiply, add);
+}
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    auto impl = resolveCall!(freeFunctionByFirstName)(r.injector, &freeFunctionByFirstName);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with free function and params by first name passed");
+}
+
+@OnParameter!("power", Autowire!Power)
+auto freeFunctionByMiddleName(Operator multiply, Operator power, Add add)
+{
+    return new FooForFunction(power, multiply, add);
+}
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    auto impl = resolveCall!(freeFunctionByMiddleName)(r.injector, &freeFunctionByMiddleName);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with free function and params by middle name passed");
+}
+
+@OnParameter!("power", Autowire!Power)
+auto freeFunctionByLastName(Operator multiply, Add add, Operator power)
+{
+    return new FooForFunction(power, multiply, add);
+}
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    auto impl = resolveCall!(freeFunctionByLastName)(r.injector, &freeFunctionByLastName);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with free function and params by last name passed");
+}
+
+class ConfigLike {
+    @OnParameter!(0, Autowire!Power)
+    static auto staticMethodByFirstIdx(Operator power, Operator multiply, Add add)
+    {
+        return new FooForFunction(power, multiply, add);
+    }
+    
+    @OnParameter!(0, Autowire!Power)
+    auto instanceMethodByFirstIdx(Operator power, Operator multiply, Add add)
+    {
+        return new FooForFunction(power, multiply, add);
+    }
+    
+    @OnParameter!("power", Autowire!Power)
+    static auto staticMethodByFirstName(Operator power, Operator multiply, Add add)
+    {
+        return new FooForFunction(power, multiply, add);
+    }
+    
+    @OnParameter!("power", Autowire!Power)
+    auto instanceMethodByFirstName(Operator power, Operator multiply, Add add)
+    {
+        return new FooForFunction(power, multiply, add);
+    }
+    
+    @OnParameter!(1, Autowire!Power)
+    static auto staticMethodByMiddleIdx(Operator multiply, Operator power, Add add)
+    {
+        return new FooForFunction(power, multiply, add);
+    }
+    
+    @OnParameter!(1, Autowire!Power)
+    auto instanceMethodByMiddleIdx(Operator multiply, Operator power, Add add)
+    {
+        return new FooForFunction(power, multiply, add);
+    }
+    
+    @OnParameter!("power", Autowire!Power)
+    static auto staticMethodByMiddleName(Operator multiply, Operator power, Add add)
+    {
+        return new FooForFunction(power, multiply, add);
+    }
+    
+    @OnParameter!("power", Autowire!Power)
+    auto instanceMethodByMiddleName(Operator multiply, Operator power, Add add)
+    {
+        return new FooForFunction(power, multiply, add);
+    }
+    
+    @OnParameter!(2, Autowire!Power)
+    static auto staticMethodByLastIdx(Add add, Operator multiply, Operator power)
+    {
+        return new FooForFunction(power, multiply, add);
+    }
+    
+    @OnParameter!(2, Autowire!Power)
+    auto instanceMethodByLastIdx(Add add, Operator multiply, Operator power)
+    {
+        return new FooForFunction(power, multiply, add);
+    }
+    
+    @OnParameter!("power", Autowire!Power)
+    static auto staticMethodByLastName(Add add, Operator multiply, Operator power)
+    {
+        return new FooForFunction(power, multiply, add);
+    }
+    
+    @OnParameter!("power", Autowire!Power)
+    auto instanceMethodByLastName(Add add, Operator multiply, Operator power)
+    {
+        return new FooForFunction(power, multiply, add);
+    }
+}
+
+//todo it would be good to test what happens when there are overloads of the method - both using __traits(getOverloads, X, "y") and X.y
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    auto impl = resolveCall!(ConfigLike.staticMethodByFirstIdx)(r.injector, &ConfigLike.staticMethodByFirstIdx);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with static method and params by first idx passed");
+}
+
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    ConfigLike instance = new ConfigLike;
+    auto impl = resolveCall!(ConfigLike.instanceMethodByFirstIdx)(r.injector, &instance.instanceMethodByFirstIdx);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with instance method and params by first idx passed");
+}
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    auto impl = resolveCall!(ConfigLike.staticMethodByFirstName)(r.injector, &ConfigLike.staticMethodByFirstName);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with static method and params by first name passed");
+}
+
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    ConfigLike instance = new ConfigLike;
+    auto impl = resolveCall!(ConfigLike.instanceMethodByFirstName)(r.injector, &instance.instanceMethodByFirstName);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with instance method and params by first name passed");
+}
+
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    auto impl = resolveCall!(ConfigLike.staticMethodByMiddleIdx)(r.injector, &ConfigLike.staticMethodByMiddleIdx);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with static method and params by middle idx passed");
+}
+
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    ConfigLike instance = new ConfigLike;
+    auto impl = resolveCall!(ConfigLike.instanceMethodByMiddleIdx)(r.injector, &instance.instanceMethodByMiddleIdx);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with instance method and params by middle idx passed");
+}
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    auto impl = resolveCall!(ConfigLike.staticMethodByMiddleName)(r.injector, &ConfigLike.staticMethodByMiddleName);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with static method and params by middle name passed");
+}
+
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    ConfigLike instance = new ConfigLike;
+    auto impl = resolveCall!(ConfigLike.instanceMethodByMiddleName)(r.injector, &instance.instanceMethodByMiddleName);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with instance method and params by middle name passed");
+}
+
+
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    auto impl = resolveCall!(ConfigLike.staticMethodByLastIdx)(r.injector, &ConfigLike.staticMethodByLastIdx);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with static method and params by last idx passed");
+}
+
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    ConfigLike instance = new ConfigLike;
+    auto impl = resolveCall!(ConfigLike.instanceMethodByLastIdx)(r.injector, &instance.instanceMethodByLastIdx);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with instance method and params by last idx passed");
+}
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    auto impl = resolveCall!(ConfigLike.staticMethodByLastName)(r.injector, &ConfigLike.staticMethodByLastName);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with static method and params by last name passed");
+}
+
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    ConfigLike instance = new ConfigLike;
+    auto impl = resolveCall!(ConfigLike.instanceMethodByLastName)(r.injector, &instance.instanceMethodByLastName);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with instance method and params by last name passed");
 }

--- a/test/glued/testsuites/application/di/resolveCall.d
+++ b/test/glued/testsuites/application/di/resolveCall.d
@@ -1,0 +1,61 @@
+module glued.testsuites.application.di.resolveCall;
+
+import foo.api;
+import foo.operators;
+
+import glued.application;
+import glued.logging;
+
+import glued.testsuites.runtime: compareResults;
+
+class FooForFunction: FooWithExpected
+{
+    Operator power;
+    
+    Operator multiply;
+    
+    Add add;
+
+    this(Operator power, Operator multiply, Add add)
+    {
+        this.power = power;
+        this.multiply = multiply;
+        this.add = add;
+    }
+
+    int foo(int x)
+    {
+        return add.apply(
+            add.apply(
+                power.apply(x, 2),
+                multiply.apply(4, x)
+            ),
+            1
+        );
+    }
+    
+    int expected(int x)
+    {
+        return x*x + 4*x + 1;
+    }
+}
+
+@OnParameter!(0, Autowire!Power)
+auto freeFunctionByIdx(Operator power, Operator multiply, Add add)
+{
+    return new FooForFunction(power, multiply, add);
+}
+
+unittest {
+    mixin CreateLogger;
+    Logger log = Logger(new StdoutSink);
+    auto r = new GluedRuntime!(at("foo"))();
+    r.start();
+    
+    import foo.api;
+    auto impl = resolveCall!(freeFunctionByIdx)(r.injector, &freeFunctionByIdx);
+    assert(impl !is null);
+
+    compareResults(impl, [0, 1, 2, 5], 5);
+    log.info.emit("resolveCall with free function and params by idx passed");
+}

--- a/test/glued/testsuites/application/di/resolveCall.d
+++ b/test/glued/testsuites/application/di/resolveCall.d
@@ -6,7 +6,7 @@ import foo.operators;
 import glued.application;
 import glued.logging;
 
-import glued.testsuites.runtime: compareResults;
+import glued.testutils;
 
 class FooForFunction: FooWithExpected
 {
@@ -46,7 +46,8 @@ auto freeFunctionByFirstIdx(Operator power, Operator multiply, Add add)
     return new FooForFunction(power, multiply, add);
 }
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -64,7 +65,8 @@ auto freeFunctionByMiddleIdx(Operator multiply, Operator power, Add add)
     return new FooForFunction(power, multiply, add);
 }
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -82,7 +84,8 @@ auto freeFunctionByLastIdx(Operator multiply, Add add, Operator power)
     return new FooForFunction(power, multiply, add);
 }
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -101,7 +104,8 @@ auto freeFunctionByFirstName(Operator power, Operator multiply, Add add)
     return new FooForFunction(power, multiply, add);
 }
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -119,7 +123,8 @@ auto freeFunctionByMiddleName(Operator multiply, Operator power, Add add)
     return new FooForFunction(power, multiply, add);
 }
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -137,7 +142,8 @@ auto freeFunctionByLastName(Operator multiply, Add add, Operator power)
     return new FooForFunction(power, multiply, add);
 }
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -149,7 +155,8 @@ unittest {
     log.info.emit("resolveCall with free function and params by last name passed");
 }
 
-class ConfigLike {
+class ConfigLike 
+{
     @OnParameter!(0, Autowire!Power)
     static auto staticMethodByFirstIdx(Operator power, Operator multiply, Add add)
     {
@@ -223,9 +230,11 @@ class ConfigLike {
     }
 }
 
-//todo it would be good to test what happens when there are overloads of the method - both using __traits(getOverloads, X, "y") and X.y
+//todo Test what happens when there are overloads of the method
+//body both using __traits(getOverloads, X, "y") and X.y
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -238,7 +247,8 @@ unittest {
 }
 
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -251,7 +261,8 @@ unittest {
     log.info.emit("resolveCall with instance method and params by first idx passed");
 }
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -264,7 +275,8 @@ unittest {
 }
 
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -278,7 +290,8 @@ unittest {
 }
 
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -291,7 +304,8 @@ unittest {
 }
 
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -304,7 +318,8 @@ unittest {
     log.info.emit("resolveCall with instance method and params by middle idx passed");
 }
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -317,7 +332,8 @@ unittest {
 }
 
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -332,7 +348,8 @@ unittest {
 
 
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -345,7 +362,8 @@ unittest {
 }
 
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -358,7 +376,8 @@ unittest {
     log.info.emit("resolveCall with instance method and params by last idx passed");
 }
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -371,7 +390,8 @@ unittest {
 }
 
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();

--- a/test/glued/testsuites/runtime.d
+++ b/test/glued/testsuites/runtime.d
@@ -2,16 +2,18 @@ module glued.testsuites.runtime;
 
 import std.algorithm;
 import std.meta;
-import std.functional;
 
 import glued.application;
 import glued.logging;
 import glued.set;
 import glued.utils;
 
+import glued.testutils;
+
 import dejector; //fixme only for queryString; same old story -.-'
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto runtime = new GluedRuntime!(at("apps.app1"))();
@@ -25,7 +27,8 @@ unittest {
 }
 
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("ex1"))();
@@ -37,38 +40,8 @@ unittest {
     log.info.emit("runtime with ex1 passed");
 }
 
-import foo.api: FooWithExpected;
-
-//todo this could go to testutils or smth like that
-void compareResults(FooWithExpected f, int[] fixed, size_t toRandomize){
-    import std.random;
-    import core.exception;
-    import std.stdio;
-    
-    int[] toCheck;
-    toCheck ~= fixed;
-    while (toCheck.length < (toRandomize+fixed.length))
-    {
-        int candidate = uniform!int;
-        if (!toCheck.canFind(candidate))
-            toCheck ~= candidate;
-    }
-    foreach (i; toCheck)
-    {
-        auto result = f.foo(i);
-        auto expectedResult = f.expected(i);
-        try
-        {
-            assert(result == expectedResult);
-        } catch (AssertError e)
-        {
-            writeln("ERROR: Expected ", expectedResult, "; got ", result, " instead! (arg: ", i, ")");
-            throw e;
-        }
-    }
-}
-
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -82,7 +55,8 @@ unittest {
     log.info.emit("runtime with foo/byField passed");
 }
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -96,7 +70,8 @@ unittest {
     log.info.emit("runtime with foo/byConstructor passed");
 }
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -110,7 +85,8 @@ unittest {
     log.info.emit("runtime with foo/byProperty passed");
 }
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("foo"))();
@@ -124,7 +100,8 @@ unittest {
     log.info.emit("runtime with foo/mixed passed");
 }
 
-unittest {
+unittest 
+{
     mixin CreateLogger;
     Logger log = Logger(new StdoutSink);
     auto r = new GluedRuntime!(at("ex3"))();

--- a/test/glued/testsuites/runtime.d
+++ b/test/glued/testsuites/runtime.d
@@ -2,6 +2,7 @@ module glued.testsuites.runtime;
 
 import std.algorithm;
 import std.meta;
+import std.functional;
 
 import glued.application;
 import glued.logging;
@@ -38,8 +39,12 @@ unittest {
 
 import foo.api: FooWithExpected;
 
+//todo this could go to testutils or smth like that
 void compareResults(FooWithExpected f, int[] fixed, size_t toRandomize){
     import std.random;
+    import core.exception;
+    import std.stdio;
+    
     int[] toCheck;
     toCheck ~= fixed;
     while (toCheck.length < (toRandomize+fixed.length))
@@ -49,7 +54,18 @@ void compareResults(FooWithExpected f, int[] fixed, size_t toRandomize){
             toCheck ~= candidate;
     }
     foreach (i; toCheck)
-        assert(f.foo(i) == f.expected(i));
+    {
+        auto result = f.foo(i);
+        auto expectedResult = f.expected(i);
+        try
+        {
+            assert(result == expectedResult);
+        } catch (AssertError e)
+        {
+            writeln("ERROR: Expected ", expectedResult, "; got ", result, " instead! (arg: ", i, ")");
+            throw e;
+        }
+    }
 }
 
 unittest {

--- a/test/glued/testutils.d
+++ b/test/glued/testutils.d
@@ -1,0 +1,38 @@
+module glued.testutils;
+
+interface FooWithExpected 
+{
+    int foo(int x);
+    int expected(int x);
+}
+
+void compareResults(FooWithExpected f, int[] fixed, size_t toRandomize)
+{
+    import std.random;
+    import core.exception;
+    import std.stdio;
+    import std.algorithm;
+    
+    int[] toCheck;
+    toCheck ~= fixed;
+    while (toCheck.length < (toRandomize+fixed.length))
+    {
+        int candidate = uniform!int;
+        if (!toCheck.canFind(candidate))
+            toCheck ~= candidate;
+    }
+    foreach (i; toCheck)
+    {
+        auto result = f.foo(i);
+        auto expectedResult = f.expected(i);
+        try
+        {
+            assert(result == expectedResult);
+        } catch (AssertError e)
+        {
+            writeln("ERROR: Expected ", expectedResult, "; got ", result, " instead! (arg: ", i, ")");
+            throw e;
+        }
+    }
+}
+

--- a/utils/source/glued/utils.d
+++ b/utils/source/glued/utils.d
@@ -56,7 +56,7 @@ template toType(alias T){
 
 //fixme fugly name, its nothing to do with annotations, but I have no better idea now
 template toAnnotableType(alias T){
-    alias toTypes = AliasSeq!(NoDuplicates!(typeof(T), toType!(T)));
+    alias toAnnotableType = AliasSeq!(NoDuplicates!(typeof(T), toType!(T)));
 }
 
 enum isType(T) = (__traits(isTemplate, T) || is(T == class) || is(T == interface) || is(T == struct) || is(T == enum));


### PR DESCRIPTION
* [x] retrieve param annotations by param name
* [x] retrieve param annotations by param idx
* [x] new param resolving rules:
  * autowire by default
  * customize autowiring with param annotations
  * disabling autowiring parameters should be out of scope
  * this is NOT providing partial function equivalent to to original with parameters resolved; it should call the target in instantiation point
